### PR TITLE
Disks and networks order in response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,26 @@
 run: 
 	export CONF_PATH="conf/conf.yml" && \
 	go run ./cmd/main.go
+
 test:
 	go test ./...
+
 docker-run:
 	sudo docker compose --env-file .env/dev.env --file deploy/docker-compose.yml up --build --force-recreate -d 
+
 docker-build:
 	sudo docker compose --env-file .env/dev.env --file deploy/docker-compose.yml build --no-cache
+
 docker-rm:
 	sudo docker compose --env-file .env/dev.env --file deploy/docker-compose.yml rm -f
+
 docker-logs:
 	sudo docker logs -f $(shell sudo docker ps | grep unraid-simple-monitoring-api | cut -d " " -f 1)
-docker-push: test
-	sudo docker compose --env-file .env/prod.env --file deploy/docker-compose.yml build --no-cache --push
+
+docker-push-qa: test
+	sudo docker compose --env-file .env/prod.env --file deploy/docker-compose.yml build --no-cache && \
+	sudo docker tag nebn/unraid-simple-monitoring-api:latest ghcr.io/nebn/unraid-simple-monitoring-api:qa && \
+	sudo docker push ghcr.io/nebn/unraid-simple-monitoring-api:qa
+
 docker-prune:
 	sudo docker image prune -f && sudo docker container prune -f	

--- a/internal/util/model.go
+++ b/internal/util/model.go
@@ -1,0 +1,6 @@
+package util
+
+type IndexedValue[T any] struct {
+	Index int
+	Value T
+}


### PR DESCRIPTION
Fixes #3

Disks and networks in the JSON response will be in the same order as in conf.yml, this will make it possible to map them reliably in Homepage using the array index notation.